### PR TITLE
add additional gulp tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env
 test/**/test_bundle.js
 **/.DS_Store
+todo.txt

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,17 +1,40 @@
 var gulp = require('gulp');
+var karmaServer = require('karma').Server;
 var mocha = require('gulp-mocha');
+var concatCss = require('gulp-concat-css');
 var minifyCss = require('gulp-minify-css');
-var gulpWatch = require('gulp-watch');
 var sass = require('gulp-sass');
 var maps = require('gulp-sourcemaps');
-var testFiles = ['./test/**/*.js'];
 var webpack = require('webpack-stream');
+var jshint = require('gulp-jshint');
+
+// Covering JS for server, router, database models, and any library files.
+var backendFiles = ['server.js',
+                 __dirname + '/routes/**/*.js',
+                 __dirname + '/models/**/*.js',
+                 __dirname + '/lib/**/*.js'];
+
+// Covering all JS for client-side.
+var appFiles = [__dirname + '/app/**/*.js'];
+
+// All test files, including gulpfile (bundled for linting purposes)
+var testFiles = [__dirname + '/test/**/*.js',
+                'gulpfile.js'];
+
+// Any files copied directly to build folder, including HTML & images.
+var staticFiles = ['app/**/*.html'];
+
+
+/* * * * * * * * * * * * * * * * * *
+            BUILD TASKS
+ * * * * * * * * * * * * * * * * * */
 
 gulp.task('static:dev', function() {
-  gulp.src('app/**/*.html')
+  gulp.src(staticFiles)
   .pipe(gulp.dest('build/'));
 });
 
+// Bundles all client-side JS.
 gulp.task('webpack:dev', function() {
   return gulp.src('app/js/entry.js')
   .pipe(webpack({
@@ -26,20 +49,13 @@ gulp.task('styles:dev', function() {
   return gulp.src(['app/styles/**/*.scss'])
     .pipe(maps.init())
     .pipe(sass().on('error', sass.logError))
+    .pipe(concatCss('styles.min.css'))
     .pipe(minifyCss())
     .pipe(maps.write('./'))
-  .pipe(gulp.dest('build/styles/'));
+    .pipe(gulp.dest('build/styles/'));
 });
 
-gulp.task('css:watch', function () {
-  gulp.watch('app/**/styles/*.css', ['styles:dev']);
-});
-
-gulp.task('scripts:dev', function() {
-  return gulp.src('app/js/**/*.js')
-  .pipe(gulp.dest('build/js/'));
-});
-
+// For client-side tests.
 gulp.task('webpack:test', function() {
   return gulp.src('test/client/test_entry.js')
   .pipe(webpack ({
@@ -50,5 +66,83 @@ gulp.task('webpack:test', function() {
   .pipe(gulp.dest('test/client/'));
 });
 
-gulp.task('build:dev', ['webpack:dev', 'static:dev', 'styles:dev', 'scripts:dev', 'images:dev']);
-gulp.task('default', ['build:dev']);
+/* * * * * * * * * * * * * * * * * *
+            LINT TASKS
+ * * * * * * * * * * * * * * * * * */
+
+gulp.task('jshint:backendFiles', function() {
+  return gulp.src(backendFiles)
+    .pipe(jshint({
+      node: true,
+    }))
+    .pipe(jshint.reporter('default'));
+});
+
+gulp.task('jshint:testfiles', function() {
+  return gulp.src(testFiles)
+    .pipe(jshint({
+      node: true,
+      globals: {
+        angular: true,
+        before: true,
+        after: true,
+        it: true,
+        expect: true
+      }
+    }))
+    .pipe(jshint.reporter('default'));
+});
+
+gulp.task('jshint:appfiles', function() {
+  return gulp.src(appfiles)
+    .pipe(jshint({
+      node: true,
+      globals: {
+        angular: true
+      }
+    }))
+    .pipe(jshint.reporter('default'));
+});
+
+
+/* * * * * * * * * * * * * * * * * *
+            TEST TASKS
+ * * * * * * * * * * * * * * * * * */
+
+
+gulp.task('mocha', function() {
+  return gulp.src(backendFiles)
+    .pipe(mocha());
+});
+
+gulp.task('karma', function() {
+  new karmaServer({
+    configFile: __dirname + '/karma.conf.js'
+  }, done).start();
+});
+
+/* * * * * * * * * * * * * * * * * *
+            WATCH TASKS
+ * * * * * * * * * * * * * * * * * */
+
+gulp.task('build:watch', function() {
+  gulp.watch(staticFiles, ['static:dev']);
+  gulp.watch(appFiles, ['webpack:dev', 'karma']);
+  gulp.watch('app/styles/**/*.scss', ['styles:dev']);
+  //gulp.watch('test/client/*.js', ['webpack:test']);
+});
+
+gulp.task('app:watch', function() {
+  gulp.watch(backendFiles, ['jshint:backendFiles', 'mocha']);
+  gulp.watch(testFiles, ['jshint:testfiles']);
+});
+
+/* * * * * * * * * * * * * * * * * *
+        QUICK TASKS & DEFAULT
+ * * * * * * * * * * * * * * * * * */
+
+gulp.task('build', ['static:dev', 'webpack:dev', 'styles:dev', 'webpack:test']);
+gulp.task('lint', ['jshint:backendFiles', 'jshint:testfiles', 'jshint:devfiles']);
+gulp.task('test', ['mocha', 'karma']);
+gulp.task('watch', ['build:watch', 'app:watch']);
+gulp.task('default', ['build', 'watch']);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "angular": "^1.4.8",
     "angular-mocks": "^1.4.8",
+    "angular-route": "^1.4.8",
     "chai": "^3.4.1",
     "chai-http": "^1.0.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
Causes merge conflicts, no! Take a look at what I've constructed--totally open to changes. The idea is to create a task for each separate piece we might want to run, but also provide quick bundled tasks, which I imagine we'd use most often (built/lint/test/watch/default).

I also added "todo.txt" to the gitignore, because my list of things to follow up on was getting crazy!
